### PR TITLE
Add configuration for VS/CMake. Fix PnP connection string

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ build/
 VisualGDB/
 .vscode/
 .azure_config.h
+.vs/

--- a/MXChip/AZ3166/CMakeSettings.json
+++ b/MXChip/AZ3166/CMakeSettings.json
@@ -1,0 +1,54 @@
+﻿{
+  "configurations": [
+    {
+      "name": "IoT-Debug",
+      "generator": "Ninja",
+      "configurationType": "Debug",
+      "buildRoot": "${projectDir}\\out\\build\\${name}",
+      "installRoot": "${projectDir}\\out\\install\\${name}",
+      "cmakeCommandArgs": "",
+      "buildCommandArgs": "",
+      "ctestCommandArgs": "",
+      "cmakeToolchain": "${projectDir}/../../cmake/arm-gcc-cortex-m4.cmake",
+      "inheritEnvironments": [ "gcc-arm" ],
+      "variables": [
+        {
+          "name": "CMAKE_C_COMPILER",
+          "value": "arm-none-eabi-gcc.exe",
+          "type": "STRING"
+        },
+        {
+          "name": "CMAKE_CXX_COMPILER",
+          "value": "arm-none-eabi-g++.exe",
+          "type": "STRING"
+        },
+        {
+          "name": "CMAKE_C_FLAGS",
+          "value": "-nostartfiles",
+          "type": "STRING"
+        },
+        {
+          "name": "CMAKE_CXX_FLAGS",
+          "value": "-nostartfiles -fno-rtti -fno-exceptions",
+          "type": "STRING"
+        },
+        {
+          "name": "CMAKE_CXX_STANDARD",
+          "value": "14",
+          "type": "STRING"
+        },
+        {
+          "name": "CMAKE_SYSTEM_NAME",
+          "value": "Generic",
+          "type": "STRING"
+        },
+        {
+          "name": "CMAKE_SYSTEM_PROCESSOR",
+          "value": "arm",
+          "type": "STRING"
+        }
+      ],
+      "intelliSenseMode": "linux-gcc-arm"
+    }
+  ]
+}

--- a/core/src/azure_iot_mqtt/azure_iot_mqtt.c
+++ b/core/src/azure_iot_mqtt/azure_iot_mqtt.c
@@ -14,7 +14,7 @@
 #include "azure_iot_cert.h"
 #include "azure_iot_mqtt/sas_token.h"
 
-#define USERNAME                "%s/%s/?api-version=2020-05-31-preview&digital-twin-model-id=%s"
+#define USERNAME                "%s/%s/?api-version=2020-05-31-preview&model-id=%s"
 #define PUBLISH_TELEMETRY_TOPIC "devices/%s/messages/events/"
 
 #define DEVICE_MESSAGE_BASE  "messages/devicebound/"


### PR DESCRIPTION
This PR adds a CMakeSettings.json file to configure VS to use gcc-arm-eabi

Fix the connection string for PnP model announcement

/c @liydu @ryanwinter 