### PR TITLE
Switch to pre-built Docker image

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 // For format details, see https://aka.ms/vscode-remote/devcontainer.json
 {
-    "dockerfile": "Dockerfile",
+    "image": "kartben/azurertos-gnuarm:latest",
     "extensions": [
         "ms-vscode.cpptools",
         "ms-vscode.cmake-tools",


### PR DESCRIPTION
This saves 30sec to 1min of workspace provisioning time by means of using a pre-built Docker image. 
This will likely be even faster once we have this image par of the Microsoft Container Registry and that all its layers are effectively cached.