### PR TITLE
rotate through the pool.ntp.org dns servers

### DIFF
--- a/NXP/MIMXRT1060-EVK/tools/flash.bat
+++ b/NXP/MIMXRT1060-EVK/tools/flash.bat
@@ -4,4 +4,4 @@
 setlocal
 cd /d %~dp0\..
 
-openocd -f tools\nxp_mimxrt1060-evk.cfg -c init -c "program build/app/mimxrt1060_azure_iot.elf"
+openocd -f tools\nxp_mimxrt1060-evk.cfg -c init -c "program build/app/mimxrt1060_azure_iot.elf verify reset exit"


### PR DESCRIPTION
Some routers fail to resolve a new IP address when resolving ntp.pool.org resulting in the same broken IP being allocated every time. This will rotate through the 4 dns server to force a new IP:
* 0.pool.ntp.org
* 1.pool.ntp.org
* 2.pool.ntp.org
* 3.pool.ntp.org