### PR TITLE
fix to support different ubuntu release codenames

### DIFF
--- a/tools/get-toolchain.sh
+++ b/tools/get-toolchain.sh
@@ -8,7 +8,8 @@ sudo apt-get install apt-transport-https ca-certificates gnupg software-properti
 
 wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | sudo apt-key add -
 
-sudo apt-add-repository 'deb https://apt.kitware.com/ubuntu/ bionic main'
+CODENAME=$(lsb_release -c | cut -f2 -d':' | sed 's/\t//')
+sudo apt-add-repository "deb https://apt.kitware.com/ubuntu/ $CODENAME main"
 
 sudo apt-get update
 sudo apt-get install  gcc-arm-none-eabi ninja-build cmake 


### PR DESCRIPTION

apt.kitware.com repo is set to bionic statically which does not work for focal (20.04). This is a simple change to use the current release codename. Tested on Ubuntu 20.04 (focal).