### PR TITLE
Update OpenOCD and enable RTOS detection

### DIFF
--- a/MXChip/AZ3166/.vs/launch.vs.json
+++ b/MXChip/AZ3166/.vs/launch.vs.json
@@ -13,7 +13,7 @@
             "miDebuggerPath": "arm-none-eabi-gdb",
             "miDebuggerServerAddress": "localhost:3333",
             "debugServerPath": "openocd",
-            "debugServerArgs": "-f board/stm32f4discovery.cfg",
+            "debugServerArgs": "-f board/stm32f4discovery.cfg -c \"$_TARGETNAME configure -rtos auto\"",
             "serverStarted": "Listening on port .* for gdb connections",
             "filterStderr": true,
             "stopAtConnect": true,

--- a/MXChip/AZ3166/.vscode/launch.json
+++ b/MXChip/AZ3166/.vscode/launch.json
@@ -35,7 +35,7 @@
             "miDebuggerPath": "arm-none-eabi-gdb",
             "miDebuggerServerAddress": "localhost:3333",
             "debugServerPath": "openocd",
-            "debugServerArgs": "-f board/stm32f4discovery.cfg",
+            "debugServerArgs": "-f board/stm32f4discovery.cfg -c \"$_TARGETNAME configure -rtos auto\"",
             "serverStarted": "Listening on port .* for gdb connections",
             "filterStderr": true,
             "stopAtConnect": true,

--- a/MXChip/AZ3166/vcpkg-configuration.json
+++ b/MXChip/AZ3166/vcpkg-configuration.json
@@ -9,7 +9,7 @@
   "requires": {
     "microsoft:compilers/arm/gcc": "* 2020.10.0",
     "microsoft:tools/compuphase/termite": "* 3.4.0",
-    "microsoft:tools/microsoft/openocd": "* 0.11.0",
+    "microsoft:tools/microsoft/openocd": "0.11.0-ms1",
     "microsoft:tools/kitware/cmake": "* 3.20.1",
     "microsoft:tools/ninja-build/ninja": "* 1.10.2"
   }

--- a/STMicroelectronics/B-L475E-IOT01A/.vs/launch.vs.json
+++ b/STMicroelectronics/B-L475E-IOT01A/.vs/launch.vs.json
@@ -13,7 +13,7 @@
             "miDebuggerPath": "arm-none-eabi-gdb",
             "miDebuggerServerAddress": "localhost:3333",
             "debugServerPath": "openocd",
-            "debugServerArgs": "-f board/stm32l4discovery.cfg",
+            "debugServerArgs": "-f board/stm32l4discovery.cfg -c \"$_TARGETNAME configure -rtos auto\"",
             "serverStarted": "Listening on port .* for gdb connections",
             "filterStderr": true,
             "stopAtConnect": true,

--- a/STMicroelectronics/B-L475E-IOT01A/.vscode/launch.json
+++ b/STMicroelectronics/B-L475E-IOT01A/.vscode/launch.json
@@ -25,7 +25,7 @@
             "miDebuggerPath": "arm-none-eabi-gdb",
             "miDebuggerServerAddress": "localhost:3333",
             "debugServerPath": "openocd",
-            "debugServerArgs": "-f board/stm32l4discovery.cfg",
+            "debugServerArgs": "-f board/stm32l4discovery.cfg -c \"$_TARGETNAME configure -rtos auto\"",
             "serverStarted": "Listening on port .* for gdb connections",
             "filterStderr": true,
             "stopAtConnect": true,

--- a/STMicroelectronics/B-L475E-IOT01A/vcpkg-configuration.json
+++ b/STMicroelectronics/B-L475E-IOT01A/vcpkg-configuration.json
@@ -9,7 +9,7 @@
   "requires": {
     "microsoft:compilers/arm/gcc": "* 2020.10.0",
     "microsoft:tools/compuphase/termite": "* 3.4.0",
-    "microsoft:tools/microsoft/openocd": "* 0.11.0",
+    "microsoft:tools/microsoft/openocd": "0.11.0-ms1",
     "microsoft:tools/kitware/cmake": "* 3.20.1",
     "microsoft:tools/ninja-build/ninja": "* 1.10.2"
   }

--- a/STMicroelectronics/B-L4S5I-IOT01A/.vs/launch.vs.json
+++ b/STMicroelectronics/B-L4S5I-IOT01A/.vs/launch.vs.json
@@ -13,7 +13,7 @@
             "miDebuggerPath": "arm-none-eabi-gdb",
             "miDebuggerServerAddress": "localhost:3333",
             "debugServerPath": "openocd",
-            "debugServerArgs": "-f board/stm32l4discovery.cfg",
+            "debugServerArgs": "-f board/stm32l4discovery.cfg -c \"$_TARGETNAME configure -rtos auto\"",
             "serverStarted": "Listening on port .* for gdb connections",
             "filterStderr": true,
             "stopAtConnect": true,

--- a/STMicroelectronics/B-L4S5I-IOT01A/.vscode/launch.json
+++ b/STMicroelectronics/B-L4S5I-IOT01A/.vscode/launch.json
@@ -25,7 +25,7 @@
             "miDebuggerPath": "arm-none-eabi-gdb",
             "miDebuggerServerAddress": "localhost:3333",
             "debugServerPath": "openocd",
-            "debugServerArgs": "-f board/stm32l4discovery.cfg",
+            "debugServerArgs": "-f board/stm32l4discovery.cfg -c \"$_TARGETNAME configure -rtos auto\"",
             "serverStarted": "Listening on port .* for gdb connections",
             "filterStderr": true,
             "stopAtConnect": true,

--- a/STMicroelectronics/B-L4S5I-IOT01A/vcpkg-configuration.json
+++ b/STMicroelectronics/B-L4S5I-IOT01A/vcpkg-configuration.json
@@ -9,7 +9,7 @@
   "requires": {
     "microsoft:compilers/arm/gcc": "* 2020.10.0",
     "microsoft:tools/compuphase/termite": "* 3.4.0",
-    "microsoft:tools/microsoft/openocd": "* 0.11.0",
+    "microsoft:tools/microsoft/openocd": "0.11.0-ms1",
     "microsoft:tools/kitware/cmake": "* 3.20.1",
     "microsoft:tools/ninja-build/ninja": "* 1.10.2"
   }


### PR DESCRIPTION
These changes enable IDE-native thread awareness for devices using OpenOCD. The OpenOCD command line is changed to enable automatic RTOS detection, and a new version of OpenOCD is used that incorporates two small changes to provide better thread names and work with ST-Link based devices. While the new version is coming from the Microsoft fork of OpenOCD, both changes have already been merged to OpenOCD upstream ([change 1](https://review.openocd.org/c/openocd/+/6829), [change 2](https://review.openocd.org/c/openocd/+/6828)).

VS Code
![image](https://user-images.githubusercontent.com/6981284/155414847-cac1512f-f24a-4aec-af33-b285b4592269.png)

VS
![image](https://user-images.githubusercontent.com/6981284/155414862-f31b1c1b-c951-4b4d-a6d0-519541d317ad.png)
