### PR TITLE
Remove automatic RTOS detection for ST boards

### DIFF
--- a/MXChip/AZ3166/.vs/launch.vs.json
+++ b/MXChip/AZ3166/.vs/launch.vs.json
@@ -13,7 +13,7 @@
             "miDebuggerPath": "arm-none-eabi-gdb",
             "miDebuggerServerAddress": "localhost:3333",
             "debugServerPath": "openocd",
-            "debugServerArgs": "-f board/stm32f4discovery.cfg -c \"$_TARGETNAME configure -rtos auto\"",
+            "debugServerArgs": "-f board/stm32f4discovery.cfg",
             "serverStarted": "Listening on port .* for gdb connections",
             "filterStderr": true,
             "stopAtConnect": true,

--- a/MXChip/AZ3166/.vscode/launch.json
+++ b/MXChip/AZ3166/.vscode/launch.json
@@ -35,7 +35,7 @@
             "miDebuggerPath": "arm-none-eabi-gdb",
             "miDebuggerServerAddress": "localhost:3333",
             "debugServerPath": "openocd",
-            "debugServerArgs": "-f board/stm32f4discovery.cfg -c \"$_TARGETNAME configure -rtos auto\"",
+            "debugServerArgs": "-f board/stm32f4discovery.cfg",
             "serverStarted": "Listening on port .* for gdb connections",
             "filterStderr": true,
             "stopAtConnect": true,

--- a/STMicroelectronics/B-L475E-IOT01A/.vs/launch.vs.json
+++ b/STMicroelectronics/B-L475E-IOT01A/.vs/launch.vs.json
@@ -13,7 +13,7 @@
             "miDebuggerPath": "arm-none-eabi-gdb",
             "miDebuggerServerAddress": "localhost:3333",
             "debugServerPath": "openocd",
-            "debugServerArgs": "-f board/stm32l4discovery.cfg -c \"$_TARGETNAME configure -rtos auto\"",
+            "debugServerArgs": "-f board/stm32l4discovery.cfg",
             "serverStarted": "Listening on port .* for gdb connections",
             "filterStderr": true,
             "stopAtConnect": true,

--- a/STMicroelectronics/B-L475E-IOT01A/.vscode/launch.json
+++ b/STMicroelectronics/B-L475E-IOT01A/.vscode/launch.json
@@ -25,7 +25,7 @@
             "miDebuggerPath": "arm-none-eabi-gdb",
             "miDebuggerServerAddress": "localhost:3333",
             "debugServerPath": "openocd",
-            "debugServerArgs": "-f board/stm32l4discovery.cfg -c \"$_TARGETNAME configure -rtos auto\"",
+            "debugServerArgs": "-f board/stm32l4discovery.cfg",
             "serverStarted": "Listening on port .* for gdb connections",
             "filterStderr": true,
             "stopAtConnect": true,

--- a/STMicroelectronics/B-L4S5I-IOT01A/.vs/launch.vs.json
+++ b/STMicroelectronics/B-L4S5I-IOT01A/.vs/launch.vs.json
@@ -13,7 +13,7 @@
             "miDebuggerPath": "arm-none-eabi-gdb",
             "miDebuggerServerAddress": "localhost:3333",
             "debugServerPath": "openocd",
-            "debugServerArgs": "-f board/stm32l4discovery.cfg -c \"$_TARGETNAME configure -rtos auto\"",
+            "debugServerArgs": "-f board/stm32l4discovery.cfg",
             "serverStarted": "Listening on port .* for gdb connections",
             "filterStderr": true,
             "stopAtConnect": true,

--- a/STMicroelectronics/B-L4S5I-IOT01A/.vscode/launch.json
+++ b/STMicroelectronics/B-L4S5I-IOT01A/.vscode/launch.json
@@ -25,7 +25,7 @@
             "miDebuggerPath": "arm-none-eabi-gdb",
             "miDebuggerServerAddress": "localhost:3333",
             "debugServerPath": "openocd",
-            "debugServerArgs": "-f board/stm32l4discovery.cfg -c \"$_TARGETNAME configure -rtos auto\"",
+            "debugServerArgs": "-f board/stm32l4discovery.cfg",
             "serverStarted": "Listening on port .* for gdb connections",
             "filterStderr": true,
             "stopAtConnect": true,


### PR DESCRIPTION
Partially reverts #327. We're running into some issues where OpenOCD doesn't play nice with interrupt handlers (which aren't necessarily on an RTOS thread). It should be safe to stay on the newer version of OpenOCD that #327 introduces, because the only changes in that version are related to RTOS awareness.

@ryanwinter For review. I also don't have write access, so if this looks good to you, please merge.

@robotdad @aleun FYI