### PR TITLE
Update Renesas samples to use TX_TIMER_TICKS_PER_SECOND 

### DIFF
--- a/Renesas/RSK_RX65N_2MB/app/board_init.c
+++ b/Renesas/RSK_RX65N_2MB/app/board_init.c
@@ -1,6 +1,7 @@
 /* Copyright (c) Microsoft Corporation.
    Licensed under the MIT License. */
 
+#include "tx_api.h"
 #include "board_init.h"
 
 #include "r_cmt_rx_if.h"
@@ -29,7 +30,7 @@ void board_init()
     R_Config_SCI8_Start();
 
     // Create periodic timer for the system tick
-    R_CMT_CreatePeriodic(100u, timer_callback, &chan);
+    R_CMT_CreatePeriodic(TX_TIMER_TICKS_PER_SECOND, timer_callback, &chan);
 
     // Setup Ethernet hardware
     R_ETHER_Initial();

--- a/Renesas/RX65N_Cloud_Kit/app/board_init.c
+++ b/Renesas/RX65N_Cloud_Kit/app/board_init.c
@@ -1,6 +1,7 @@
 /* Copyright (c) Microsoft Corporation.
    Licensed under the MIT License. */
 
+#include "tx_api.h"
 #include "board_init.h"
 
 #include "r_cmt_rx_if.h"
@@ -26,7 +27,7 @@ void board_init()
     R_Config_SCI5_Start();
 
     // Create periodic timer for the system tick
-    R_CMT_CreatePeriodic(100u, timer_callback, &chan);
+    R_CMT_CreatePeriodic(TX_TIMER_TICKS_PER_SECOND, timer_callback, &chan);
 
     // Initialize the Option Board sensors
     init_sensors();


### PR DESCRIPTION
The board_init.c file is used for setup CMT periodic timer for the system tick in Renesas sample projects.

Renesas propose to use `TX_TIMER_TICKS_PER_SECOND` instead of a fixed value `100u` to make it modifiable by end users.