### PR TITLE
update launches to enable register view mem access

### DIFF
--- a/NXP/MIMXRT1060-EVK/.vs/launch.vs.json
+++ b/NXP/MIMXRT1060-EVK/.vs/launch.vs.json
@@ -31,6 +31,10 @@
                 {
                     "text": "-interpreter-exec console \"monitor reset halt\"",
                     "ignoreFailures": false
+                },
+                {
+                    "text": "set mem inaccessible-by-default off",
+                    "ignoreFailures": true
                 }
             ],
             "svdPath": "${workspaceRoot}/MIMXRT1062.svd"

--- a/NXP/MIMXRT1060-EVK/.vscode/launch.json
+++ b/NXP/MIMXRT1060-EVK/.vscode/launch.json
@@ -48,7 +48,14 @@
             //     "limit": 8
             // },
             "preLaunchTask": "Flash",
-            "svdPath": "${workspaceFolder}/MIMXRT1062.svd"
+            "svdPath": "${workspaceFolder}/MIMXRT1062.svd",
+            "setupCommands": [
+                {
+                    "description": "Allow reading of peripheral registers",
+                    "text": "set mem inaccessible-by-default off",
+                    "ignoreFailures": true
+                }
+            ]
         }
     ],
     "inputs": [


### PR DESCRIPTION
Based on a conversation with a user of this board, it was pointed out that by default gdbserver needs a command to be run in order to allow peripheral memory to be accessed. This change enables this. 