### PR TITLE
Enable ThreadX awareness for OpenOCD

### DIFF
--- a/MXChip/AZ3166/.vs/launch.vs.json
+++ b/MXChip/AZ3166/.vs/launch.vs.json
@@ -13,7 +13,7 @@
             "miDebuggerPath": "arm-none-eabi-gdb",
             "miDebuggerServerAddress": "localhost:3333",
             "debugServerPath": "openocd",
-            "debugServerArgs": "-f board/stm32f4discovery.cfg",
+            "debugServerArgs": "-f board/stm32f4discovery.cfg -c \"$_TARGETNAME configure -rtos auto\"",
             "serverStarted": "Listening on port .* for gdb connections",
             "filterStderr": true,
             "stopAtConnect": true,

--- a/MXChip/AZ3166/.vscode/launch.json
+++ b/MXChip/AZ3166/.vscode/launch.json
@@ -35,7 +35,7 @@
             "miDebuggerPath": "arm-none-eabi-gdb",
             "miDebuggerServerAddress": "localhost:3333",
             "debugServerPath": "openocd",
-            "debugServerArgs": "-f board/stm32f4discovery.cfg",
+            "debugServerArgs": "-f board/stm32f4discovery.cfg -c \"$_TARGETNAME configure -rtos auto\"",
             "serverStarted": "Listening on port .* for gdb connections",
             "filterStderr": true,
             "stopAtConnect": true,

--- a/MXChip/AZ3166/vcpkg-configuration.json
+++ b/MXChip/AZ3166/vcpkg-configuration.json
@@ -9,7 +9,7 @@
   "requires": {
     "microsoft:compilers/arm/gcc": "* 2020.10.0",
     "microsoft:tools/compuphase/termite": "* 3.4.0",
-    "microsoft:tools/microsoft/openocd": "0.11.0-ms1",
+    "microsoft:tools/microsoft/openocd": "0.11.0-ms2",
     "microsoft:tools/kitware/cmake": "* 3.20.1",
     "microsoft:tools/ninja-build/ninja": "* 1.10.2"
   }

--- a/STMicroelectronics/B-L4S5I-IOT01A/.vs/launch.vs.json
+++ b/STMicroelectronics/B-L4S5I-IOT01A/.vs/launch.vs.json
@@ -13,7 +13,7 @@
             "miDebuggerPath": "arm-none-eabi-gdb",
             "miDebuggerServerAddress": "localhost:3333",
             "debugServerPath": "openocd",
-            "debugServerArgs": "-f board/stm32l4discovery.cfg",
+            "debugServerArgs": "-f board/stm32l4discovery.cfg -c \"$_TARGETNAME configure -rtos auto\"",
             "serverStarted": "Listening on port .* for gdb connections",
             "filterStderr": true,
             "stopAtConnect": true,

--- a/STMicroelectronics/B-L4S5I-IOT01A/.vscode/launch.json
+++ b/STMicroelectronics/B-L4S5I-IOT01A/.vscode/launch.json
@@ -25,7 +25,7 @@
             "miDebuggerPath": "arm-none-eabi-gdb",
             "miDebuggerServerAddress": "localhost:3333",
             "debugServerPath": "openocd",
-            "debugServerArgs": "-f board/stm32l4discovery.cfg",
+            "debugServerArgs": "-f board/stm32l4discovery.cfg -c \"$_TARGETNAME configure -rtos auto\"",
             "serverStarted": "Listening on port .* for gdb connections",
             "filterStderr": true,
             "stopAtConnect": true,

--- a/STMicroelectronics/B-L4S5I-IOT01A/vcpkg-configuration.json
+++ b/STMicroelectronics/B-L4S5I-IOT01A/vcpkg-configuration.json
@@ -9,7 +9,7 @@
   "requires": {
     "microsoft:compilers/arm/gcc": "* 2020.10.0",
     "microsoft:tools/compuphase/termite": "* 3.4.0",
-    "microsoft:tools/microsoft/openocd": "0.11.0-ms1",
+    "microsoft:tools/microsoft/openocd": "0.11.0-ms2",
     "microsoft:tools/kitware/cmake": "* 3.20.1",
     "microsoft:tools/ninja-build/ninja": "* 1.10.2"
   }


### PR DESCRIPTION
Unlike the last attempt at doing this in #327 (reverted in #328), this now works inside interrupt handlers.

![image](https://user-images.githubusercontent.com/6981284/206337448-a50862d3-6c9f-423d-9b96-13da4b2b276b.png)
