### PR TITLE
Update getting started Readme, license, and device guide pages

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,8 +1,6 @@
-Getting Started Guides with Azure RTOS
-
-Copyright (c) Microsoft Corporation.
-
 MIT License
+
+Copyright (c) 2024 - present Microsoft Corporation
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -14,7 +12,7 @@ furnished to do so, subject to the following conditions:
 The above copyright notice and this permission notice shall be included in all
 copies or substantial portions of the Software.
 
-THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
 AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER

--- a/MXChip/AZ3166/readme.md
+++ b/MXChip/AZ3166/readme.md
@@ -12,12 +12,7 @@ products:
 
 # Connect an MXCHIP AZ3166 to Azure IoT
 
-[![Quickstart article](../../docs/media/docs-link-buttons/azure-quickstart.svg)](https://docs.microsoft.com/azure/iot-develop/quickstart-devkit-mxchip-az3166-iot-hub)
-[![Documentation](../../docs/media/docs-link-buttons/azure-documentation.svg)](https://docs.microsoft.com/azure/iot-develop/)
-
-The **Quickstart** button above provides the complete steps for creating an IoT Hub application and then configuring, building and flashing the device.
-
-For guidance on connecting additional devices, see [Getting started with IoT device development](https://learn.microsoft.com/azure/iot-develop/about-getting-started-device-development).
+This guide steps through the basic process to flash a device and connect to Azure IoT. 
 
 ## What you need
 

--- a/MXChip/AZ3166/readme.md
+++ b/MXChip/AZ3166/readme.md
@@ -1,12 +1,11 @@
 ---
 page_type: sample
-description: Connect an MXCHIP AZ3166 to Azure IoT using Azure RTOS
+description: Connect an MXCHIP AZ3166 to Azure IoT
 languages:
 - c
 products:
 - azure-iot
 - azure-iot-pnp
-- azure-rtos
 - azure-iot-central
 ---
 
@@ -24,7 +23,7 @@ This guide steps through the basic process to flash a device and connect to Azur
 
 1. Recursively clone the repository:
     ```shell
-    git clone --recursive https://github.com/azure-rtos/getting-started.git
+    git clone --recursive https://github.com/eclipse-threadx/getting-started.git
     ```
 
 1. Install the development tools:

--- a/Microchip/ATSAME54-XPRO/readme.md
+++ b/Microchip/ATSAME54-XPRO/readme.md
@@ -1,12 +1,11 @@
 ---
 page_type: sample
-description: Connecting an Microchip ATSAME54-XPro device to Azure IoT using Azure RTOS
+description: Connecting an Microchip ATSAME54-XPro device to Azure IoT
 languages:
 - c
 products:
 - azure-iot
 - azure-iot-pnp
-- azure-rtos
 - azure-iot-central
 ---
 
@@ -28,7 +27,7 @@ This guide steps through the basic process to flash a device and connect to Azur
 
 1. Recursively clone the repository:
     ```shell
-    git clone --recursive https://github.com/azure-rtos/getting-started.git
+    git clone --recursive https://github.com/eclipse-threadx/getting-started.git
     ```
 
 1. Install the development tools:

--- a/Microchip/ATSAME54-XPRO/readme.md
+++ b/Microchip/ATSAME54-XPRO/readme.md
@@ -12,12 +12,7 @@ products:
 
 # Connect an Microchip ATSAME54-XPro evaluation kit to Azure IoT
 
-[![Quickstart article](../../docs/media/docs-link-buttons/azure-quickstart.svg)](https://docs.microsoft.com/azure/iot-develop/quickstart-devkit-microchip-atsame54-xpro-iot-hub)
-[![Documentation](../../docs/media/docs-link-buttons/azure-documentation.svg)](https://docs.microsoft.com/azure/iot-develop/)
-
-The **Quickstart** button above provides the complete steps for creating an IoT Hub application and then configuring, building and flashing the device.
-
-For guidance on connecting additional devices, see [Getting started with IoT device development](https://learn.microsoft.com/azure/iot-develop/about-getting-started-device-development).
+This guide steps through the basic process to flash a device and connect to Azure IoT. 
 
 ## What you need
 

--- a/NXP/MIMXRT1050-EVKB/readme.md
+++ b/NXP/MIMXRT1050-EVKB/readme.md
@@ -12,12 +12,7 @@ products:
 
 # Connect an NXP MIMXRT1050-EVKB Evaluation kit to Azure IoT
 
-[![Quickstart article](../../docs/media/docs-link-buttons/azure-quickstart.svg)](https://docs.microsoft.com/azure/iot-develop/quickstart-devkit-nxp-mimxrt1050-evkb)
-[![Documentation](../../docs/media/docs-link-buttons/azure-documentation.svg)](https://docs.microsoft.com/azure/iot-develop/)
-
-The **Quickstart** button above provides the complete steps for creating an IoT Central application and then configuring, building and flashing the device.
-
-For guidance on connecting additional devices, see the [Embedded device quickstarts](https://docs.microsoft.com/azure/iot-develop/quickstart-devkit-mxchip-az3166).
+This guide steps through the basic process to flash a device and connect to Azure IoT. 
 
 ## What you need
 

--- a/NXP/MIMXRT1050-EVKB/readme.md
+++ b/NXP/MIMXRT1050-EVKB/readme.md
@@ -1,12 +1,11 @@
 ---
 page_type: sample
-description: Connecting an NXP MIMXRT1050-EVKB device to Azure IoT using Azure RTOS
+description: Connecting an NXP MIMXRT1050-EVKB device to Azure IoT
 languages:
 - c
 products:
 - azure-iot
 - azure-iot-pnp
-- azure-rtos
 - azure-iot-central
 ---
 
@@ -25,7 +24,7 @@ This guide steps through the basic process to flash a device and connect to Azur
 
 1. Recursively clone the repository:
     ```shell
-    git clone --recursive https://github.com/azure-rtos/getting-started.git
+    git clone --recursive https://github.com/eclipse-threadx/getting-started.git
     ```
 
 1. Install the development tools:

--- a/NXP/MIMXRT1060-EVK/readme.md
+++ b/NXP/MIMXRT1060-EVK/readme.md
@@ -12,12 +12,7 @@ products:
 
 # Connect an NXP MIMXRT1060-EVK Evaluation kit to Azure IoT
 
-[![Quickstart article](../../docs/media/docs-link-buttons/azure-quickstart.svg)](https://learn.microsoft.com/azure/iot-develop/quickstart-devkit-nxp-mimxrt1060-evk-iot-hub)
-[![Documentation](../../docs/media/docs-link-buttons/azure-documentation.svg)](https://docs.microsoft.com/azure/iot-develop/)
-
-The **Quickstart** button above provides the complete steps for creating an IoT Hub application and then configuring, building and flashing the device.
-
-For guidance on connecting additional devices, see [Get started with IoT device development](https://learn.microsoft.com/azure/iot-develop/about-getting-started-device-development).
+This guide steps through the basic process to flash a device and connect to Azure IoT. 
 
 ## What you need
 

--- a/NXP/MIMXRT1060-EVK/readme.md
+++ b/NXP/MIMXRT1060-EVK/readme.md
@@ -1,12 +1,11 @@
 ---
 page_type: sample
-description: Connecting an NXP MIMXRT1060-EVK device to Azure IoT using Azure RTOS
+description: Connecting an NXP MIMXRT1060-EVK device to Azure IoT
 languages:
 - c
 products:
 - azure-iot
 - azure-iot-pnp
-- azure-rtos
 - azure-iot-central
 ---
 
@@ -25,7 +24,7 @@ This guide steps through the basic process to flash a device and connect to Azur
 
 1. Recursively clone the repository:
     ```shell
-    git clone --recursive https://github.com/azure-rtos/getting-started.git
+    git clone --recursive https://github.com/eclipse-threadx/getting-started.git
     ```
 
 1. Install the development tools:

--- a/README.md
+++ b/README.md
@@ -37,7 +37,3 @@ For details on contributing to this repository, see the [contributing](CONTRIBUT
 ## Reporting Security Vulnerabilities
 
 If you believe you have found a security vulnerability in any Microsoft-owned repository that meets Microsoft's definition of a security vulnerability, please report it to the [Microsoft Security Response Center](SECURITY.md).
-
-## License
-
-The Azure RTOS Getting Started guides are licensed under the [MIT](LICENSE.txt) license.

--- a/README.md
+++ b/README.md
@@ -2,12 +2,9 @@
 
 ![](https://github.com/azure-rtos/getting-started/workflows/Markdown%20links/badge.svg)
 
-The Getting Started guides will help you get started with Azure RTOS. Each guide will step through from toolchain installation to connecting the device to Azure IoT using IoT Plug and Play.
+The Getting Started guides will help you get started with Eclipse ThreadX. Each guide steps through from toolchain installation to connecting the device.
 
-For more information on Azure IoT Device Development:
-* [Azure IoT Device Development Documentation](https://docs.microsoft.com/azure/iot-develop) - Get started with Azure IoT device development
 * For product issues, bugs, or feature requests please use our GitHub issues pages for the dedicated middleware (e.g. for ThreadX: https://github.com/azure-rtos/threadx/issues).
-* [Azure RTOS Q&A](https://aka.ms/QnA/azure-rtos) - Ask a question
 
 ## Getting Started Guides
 

--- a/Renesas/RSK_RX65N_2MB/readme.md
+++ b/Renesas/RSK_RX65N_2MB/readme.md
@@ -1,12 +1,11 @@
 ---
 page_type: sample
-description: Connecting a Renesas Starter Kit+ for RX65N-2MB to Azure IoT using Azure RTOS
+description: Connecting a Renesas Starter Kit+ for RX65N-2MB to Azure IoT
 languages:
 - c
 products:
 - azure-iot
 - azure-iot-pnp
-- azure-rtos
 - azure-iot-central
 ---
 
@@ -26,7 +25,7 @@ This guide steps through the basic process to flash a device and connect to Azur
 
 1. Recursively clone the repository:
     ```shell
-    git clone --recursive https://github.com/azure-rtos/getting-started.git
+    git clone --recursive https://github.com/eclipse-threadx/getting-started.git
     ```
 
 1. Install the development tools:

--- a/Renesas/RSK_RX65N_2MB/readme.md
+++ b/Renesas/RSK_RX65N_2MB/readme.md
@@ -12,12 +12,7 @@ products:
 
 # Connect an Renesas Starter Kit+ for RX65N-2MB to Azure IoT
 
-[![Quickstart article](../../docs/media/docs-link-buttons/azure-quickstart.svg)](https://docs.microsoft.com/azure/iot-develop/quickstart-devkit-renesas-rx65n-2mb)
-[![Documentation](../../docs/media/docs-link-buttons/azure-documentation.svg)](https://docs.microsoft.com/azure/iot-develop/)
-
-The **Quickstart** button above provides the complete steps for creating an IoT Central application and then configuring, building and flashing the device.
-
-For guidance on connecting additional devices, see the [Embedded device quickstarts](https://docs.microsoft.com/azure/iot-develop/quickstart-devkit-mxchip-az3166).
+This guide steps through the basic process to flash a device and connect to Azure IoT. 
 
 ## What you need
 

--- a/Renesas/RX65N_Cloud_Kit/readme.md
+++ b/Renesas/RX65N_Cloud_Kit/readme.md
@@ -1,12 +1,11 @@
 ---
 page_type: sample
-description: Connecting a Renesas RX65N Cloud Kit to Azure IoT using Azure RTOS
+description: Connecting a Renesas RX65N Cloud Kit to Azure IoT
 languages:
 - c
 products:
 - azure-iot
 - azure-iot-pnp
-- azure-rtos
 - azure-iot-central
 ---
 
@@ -24,7 +23,7 @@ This guide steps through the basic process to flash a device and connect to Azur
 
 1. Recursively clone the repository:
     ```shell
-    git clone --recursive https://github.com/azure-rtos/getting-started.git
+    git clone --recursive https://github.com/eclipse-threadx/getting-started.git
     ```
 
 1. Install the development tools:

--- a/Renesas/RX65N_Cloud_Kit/readme.md
+++ b/Renesas/RX65N_Cloud_Kit/readme.md
@@ -12,12 +12,7 @@ products:
 
 # Connect an Renesas RX65N Cloud Kit to Azure IoT
 
-[![Quickstart article](../../docs/media/docs-link-buttons/azure-quickstart.svg)](https://docs.microsoft.com/azure/iot-develop/quickstart-devkit-renesas-rx65n-cloud-kit)
-[![Documentation](../../docs/media/docs-link-buttons/azure-documentation.svg)](https://docs.microsoft.com/azure/iot-develop/)
-
-The **Quickstart** button above provides the complete steps for creating an IoT Central application and then configuring, building and flashing the device.
-
-For guidance on connecting additional devices, see the [Embedded device quickstarts](https://docs.microsoft.com/azure/iot-develop/quickstart-devkit-mxchip-az3166).
+This guide steps through the basic process to flash a device and connect to Azure IoT. 
 
 ## What you need
 

--- a/Renesas/Synergy/readme.md
+++ b/Renesas/Synergy/readme.md
@@ -2,7 +2,7 @@
 
 Renesas provides commercially qualified software developed and optimized for the [Synergy Platform](https://www.renesas.com/products/synergy.html) with no additional fees or royalties. The Synergy Software Package (SSP) integrates all the functionality needed to build IoT applications including Eclipse ThreadX, Application Frameworks, Libraries, HAL drivers, and Board Support Packages for the Synergy kits. 
 
-Visit the [Synergy Software](https://www.renesas.com/products/synergy/software.html) website to get started with Azure RTOS and the Synergy Platform.
+Visit the [Synergy Software](https://www.renesas.com/products/synergy/software.html) website to get started with Eclipse ThreadX and the Synergy Platform.
 
 ## AE-Cloud2 Kit
 The Renesas Synergy™ [AE-Cloud2 Kit](https://www.renesas.com/products/microcontrollers-microprocessors/renesas-synergy-platform-mcus/ysaecloud2-ae-cloud2-global-lte-iot-connectivity-example) enables rapid evaluation, prototyping and development of global LTE IoT cloud connected applications using the Synergy Platform. Using the AE-CLOUD2 kit developers can easily connect IoT sensor devices to the Azure Cloud service globally using the most effective cellular IoT protocols today — Cat-M1 and Cat-NB1. It features the S5D9 MCU Group, the superset of the S5 MCU series. AE-CLOUD2 includes a variety of sensors such as lighting, microphone, temperature, humidity, pressure, air quality, geomagnetic, accelerometer, and gyroscope.

--- a/Renesas/Synergy/readme.md
+++ b/Renesas/Synergy/readme.md
@@ -1,6 +1,6 @@
 <h1>Getting started with the Renesas Synergy Platform</h1>
 
-Renesas provides commercially qualified software developed and optimized for the [Synergy Platform](https://www.renesas.com/products/synergy.html) with no additional fees or royalties. The Synergy Software Package (SSP) integrates all the functionality needed to build IoT applications including Microsoft’s Azure RTOS, Application Frameworks, Libraries, HAL drivers, and Board Support Packages for the Synergy kits. 
+Renesas provides commercially qualified software developed and optimized for the [Synergy Platform](https://www.renesas.com/products/synergy.html) with no additional fees or royalties. The Synergy Software Package (SSP) integrates all the functionality needed to build IoT applications including Eclipse ThreadX, Application Frameworks, Libraries, HAL drivers, and Board Support Packages for the Synergy kits. 
 
 Visit the [Synergy Software](https://www.renesas.com/products/synergy/software.html) website to get started with Azure RTOS and the Synergy Platform.
 
@@ -11,7 +11,7 @@ The Renesas Synergy™ [AE-Cloud2 Kit](https://www.renesas.com/products/microcon
 ## AE-Cloud2 Application Example
 Download the [Synergy MQTT/TLS Azure Cloud Connectivity Solution](https://www.renesas.com/document/scd/synergy-mqtttls-azure-cloud-connectivity-solution-application-project-0) application example.
 
-This application example uses Azure RTOS to connect to Azure IoT Hub. Using detailed steps, this document instructs first-time Microsoft Azure users how to configure the Azure IoT Hub platform to run this application example demonstration.
+This application example uses Eclipse ThreadX to connect to Azure IoT Hub. Using detailed steps, this document instructs first-time Microsoft Azure users how to configure the Azure IoT Hub platform to run this application example demonstration.
 
 Upon completion of this guide, you will be able to add the MQTT/TLS module to your own design, configure it correctly for the target application, and write code using the included application example code as a reference and efficient starting point. References to more detailed API descriptions, and other application projects that demonstrate more advanced uses of the module, are in the Synergy Software Package (SSP) User’s Manual, and serve as valuable resources in creating more complex designs.
 

--- a/STMicroelectronics/B-L475E-IOT01A/readme.md
+++ b/STMicroelectronics/B-L475E-IOT01A/readme.md
@@ -1,23 +1,17 @@
 ---
 page_type: sample
-description: Connecting an STMicroelectronics B-L475E-IOT01A device to Azure IoT using Azure RTOS
+description: Connecting an STMicroelectronics B-L475E-IOT01A device to Azure IoT
 languages:
 - c
 products:
 - azure-iot
 - azure-iot-pnp
-- azure-rtos
 - azure-iot-central
 ---
 
 # Connect an STMicroelectronics B-L475E-IOT01A / B-L4S5I-IOTOA1 Discovery kit to Azure IoT
 
-[![Quickstart article](../../docs/media/docs-link-buttons/azure-quickstart.svg)](https://docs.microsoft.com/azure/iot-develop/quickstart-devkit-stm-b-l475e-iot-hub)
-[![Documentation](../../docs/media/docs-link-buttons/azure-documentation.svg)](https://docs.microsoft.com/azure/iot-develop/)
-
-The **Quickstart** button above provides the complete steps for creating an IoT Hub application and then configuring, building and flashing the device.
-
-For guidance on connecting additional devices, see [Getting started with IoT device development](https://learn.microsoft.com/azure/iot-develop/about-getting-started-device-development).
+This guide steps through the basic process to flash a device and connect to Azure IoT. 
 
 ## What you need
 
@@ -29,7 +23,7 @@ For guidance on connecting additional devices, see [Getting started with IoT dev
 
 1. Recursively clone the repository:
     ```shell
-    git clone --recursive https://github.com/azure-rtos/getting-started.git
+    git clone --recursive https://github.com/eclipse-threadx/getting-started.git
     ```
 
 1. Install the development tools:

--- a/STMicroelectronics/B-L4S5I-IOT01A/readme.md
+++ b/STMicroelectronics/B-L4S5I-IOT01A/readme.md
@@ -1,23 +1,17 @@
 ---
 page_type: sample
-description: Connecting an STMicroelectronics L4S5I-IOT01A device to Azure IoT using Azure RTOS
+description: Connecting an STMicroelectronics L4S5I-IOT01A device to Azure IoT
 languages:
 - c
 products:
 - azure-iot
 - azure-iot-pnp
-- azure-rtos
 - azure-iot-central
 ---
 
 # Connect an STMicroelectronics B-L4S5I-IOTOA1 Discovery kit to Azure IoT
 
-[![Quickstart article](../../docs/media/docs-link-buttons/azure-quickstart.svg)](https://docs.microsoft.com/azure/iot-develop/quickstart-devkit-stm-b-l4s5i-iot-hub)
-[![Documentation](../../docs/media/docs-link-buttons/azure-documentation.svg)](https://docs.microsoft.com/azure/iot-develop/)
-
-The **Quickstart** button above provides the complete steps for creating an IoT Hub application and then configuring, building and flashing the device.
-
-For guidance on connecting additional devices, see [Getting started with IoT device development](https://learn.microsoft.com/azure/iot-develop/about-getting-started-device-development).
+This guide steps through the basic process to flash a device and connect to Azure IoT. 
 
 ## What you need
 
@@ -29,7 +23,7 @@ For guidance on connecting additional devices, see [Getting started with IoT dev
 
 1. Recursively clone the repository:
     ```shell
-    git clone --recursive https://github.com/azure-rtos/getting-started.git
+    git clone --recursive https://github.com/eclipse-threadx/getting-started.git
     ```
 
 1. Install the development tools:

--- a/STMicroelectronics/B-U585I-IOT02A/README.md
+++ b/STMicroelectronics/B-U585I-IOT02A/README.md
@@ -1,22 +1,16 @@
 ---
 page_type: sample
-description: Connecting an STMicroelectronics B-U585I-IOT02A device to Azure IoT using Azure RTOS
+description: Connecting an STMicroelectronics B-U585I-IOT02A device to Azure IoT
 languages:
 - c
 products:
 - azure-iot
 - azure-iot-pnp
-- azure-rtos
 ---
 
 # Connect an STMicroelectronics B-U585I-IOT02A Discovery kit to Azure IoT
 
-[![Quickstart article](../../docs/media/docs-link-buttons/azure-quickstart.svg)](https://docs.microsoft.com/azure/iot-develop/quickstart-devkit-stm-b-l4s5i)
-[![Documentation](../../docs/media/docs-link-buttons/azure-documentation.svg)](https://docs.microsoft.com/azure/iot-develop/)
-
-The **Quickstart** button above provides the complete steps for creating an IoT Central application and then configuring, building and flashing the device.
-
-For guidance on connecting additional devices, see the [Embedded device quickstarts](https://docs.microsoft.com/azure/iot-develop/quickstart-devkit-mxchip-az3166).
+This guide steps through the basic process to flash a device and connect to Azure IoT. 
 
 ## What you need
 
@@ -28,7 +22,7 @@ For guidance on connecting additional devices, see the [Embedded device quicksta
 
 1. Clone the repository:
     ```shell
-    git clone https://github.com/azure-rtos/getting-started.git
+    git clone https://github.com/eclipse-threadx/getting-started.git
     ```
 
 1. Add Wi-Fi and Azure IoT configuration to the config file:

--- a/SiliconLabs/EFR32MG12/readme.md
+++ b/SiliconLabs/EFR32MG12/readme.md
@@ -1,20 +1,17 @@
 ---
 page_type: sample
-description: Connecting a Silicon Labs SLWSTK6000B EFR32MG12 to Azure IoT using Azure RTOS
+description: Connecting a Silicon Labs SLWSTK6000B EFR32MG12 to Azure IoT
 languages:
 - c
 products:
 - azure-iot
 - azure-iot-pnp
-- azure-rtos
 - azure-iot-central
 ---
 
 # Getting started with the Silicon Labs SLWSTK6000B EFR32MG12 Starter Kit
 
-**Total completion time**:  30 minutes
-
-In this tutorial you use Azure RTOS to connect the Silicon Labs EFR32MG12 MCU Starter Kit to Azure IoT. The article is part of the series [Getting started with Azure RTOS](https://go.microsoft.com/fwlink/p/?linkid=2129824). The series introduces device developers to Azure RTOS, and shows how to connect several device evaluation kits to Azure IoT.
+In this guide you use Eclipse ThreadX to connect the Silicon Labs EFR32MG12 MCU Starter Kit to Azure IoT. 
 
 You will complete the following tasks:
 
@@ -44,7 +41,7 @@ Clone the following repo to download all sample device code, setup scripts, and 
 To clone the repo, run the following command:
 
 ```shell
-git clone --recursive https://github.com/azure-rtos/getting-started.git
+git clone --recursive https://github.com/eclipse-threadx/getting-started.git
 ```
 
 ### Install the tools
@@ -292,11 +289,3 @@ To remove the entire Azure IoT Central sample application and all its devices an
 1. Select **Administration** > **Your application**.
 1. Select **Delete**.
 
-## Next Steps
-
-In this tutorial you built a custom image that contains Azure RTOS sample code, and then flashed the image to the EFR32MG12 MCU Starter Kit. You also used the IoT Central portal to create Azure resources, connect the EFR32MG12 MCU Starter Kit securely to Azure, view telemetry, and send messages.
-
-* For device developers, the suggested next step is to see the other tutorials in the series [Getting started with Azure RTOS](https://go.microsoft.com/fwlink/p/?linkid=2129824).
-* If you have issues getting your device to initialize or connect after following the steps in this guide, see [Troubleshooting](https://docs.microsoft.com/azure/iot-develop/troubleshoot-embedded-device-quickstarts).
-* To learn more about how Azure RTOS components are used in the sample code for this tutorial, see [Using Azure RTOS in the Getting Started Guides](../../docs/using-azure-rtos.md).
-    >Note: Azure RTOS provides OEMs with components to secure communication and to create code and data isolation using underlying MCU/MPU hardware protection mechanisms. However, each OEM is ultimately responsible for ensuring that their device meets evolving security requirements.

--- a/mlc_config.json
+++ b/mlc_config.json
@@ -1,3 +1,8 @@
 {
-    "aliveStatusCodes": [0, 200]
+    "aliveStatusCodes": [0, 200],
+    "ignorePatterns": [
+     {
+      "pattern": "https://www.microchip.com/development-tool/.*"
+     }
+    ]
 }


### PR DESCRIPTION
- Remove links to branded RTOS docs and update RTOS references to Eclipse Threadx
- Update license txt to standard MIT
- Update getting-started repo paths in git clone command, to current repo paths in all pages
